### PR TITLE
Migrate deployment from DigitalOcean to Cloudflare Workers

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,9 +1,6 @@
 name: Deploy Website
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'apps/web/**'
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/apps/web/.eleventy.js
+++ b/apps/web/.eleventy.js
@@ -33,6 +33,7 @@ export default function(eleventyConfig) {
     // Passthrough copy
     eleventyConfig.addPassthroughCopy("js");
     eleventyConfig.addPassthroughCopy("assets");
+    eleventyConfig.addPassthroughCopy("_headers");
 
     // Collections
     eleventyConfig.addCollection("posts", function(collectionApi) {

--- a/apps/web/_headers
+++ b/apps/web/_headers
@@ -1,0 +1,11 @@
+/css/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/assets/images/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/js/*
+  Cache-Control: public, max-age=86400
+
+/*
+  Cache-Control: public, max-age=0, must-revalidate

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 name = "engeldev"
-compatibility_date = "2025-04-24"
+compatibility_date = "2026-04-24"
 
 [assets]
 directory = "apps/web/_site"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,5 @@
+name = "engeldev"
+compatibility_date = "2025-04-24"
+
+[assets]
+directory = "apps/web/_site"


### PR DESCRIPTION
## Summary

- Add `wrangler.toml` to configure Cloudflare Workers static asset deployment pointing at `apps/web/_site`
- Disable automatic GitHub Actions deploy trigger (changed from `push` to `workflow_dispatch`) — Cloudflare's built-in CI replaces it
- Add `apps/web/_headers` with long-lived cache TTLs for CSS, images, and JS assets
- Passthrough copy `_headers` through Eleventy so it lands in `_site/`

## Why

Migrating hosting from DigitalOcean (rsync over SSH) to Cloudflare Workers for global CDN, simpler deploys, and no server to maintain.

## Reviewer notes

- No changes to the Eleventy build itself — purely deployment config
- CSS already uses `?v={{ buildTime }}` for cache-busting, so the 1-year TTL on `/css/*` is safe
- JS files get a 24-hour TTL (no cache buster on them, but they change rarely)
- HTML gets `max-age=0, must-revalidate` so page content is always fresh
- The old GitHub Actions workflow is preserved but manual-only in case it's needed as a fallback